### PR TITLE
#1 Refactor to use dependency injection across projects

### DIFF
--- a/AskGenAi.Application/AskGenAi.Application.csproj
+++ b/AskGenAi.Application/AskGenAi.Application.csproj
@@ -7,9 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AskGenAi.Application/ServiceCollectionExtensions.cs
+++ b/AskGenAi.Application/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿using AskGenAi.Application.Services;
+using Microsoft.Extensions.DependencyInjection;
+using AskGenAi.Application.UseCases;
+using AskGenAi.Core.Interfaces;
+
+namespace AskGenAi.Application;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        services.AddScoped<IHistoryBuilder, HistoryBuilder>();
+
+        services.AddScoped<IClassNormalizerService, ClassNormalizerService>();
+        services.AddScoped<IResponseAiGenerator, ResponseAiGenerator>();
+
+        return services;
+    }
+}

--- a/AskGenAi.Application/UseCases/ClassNormalizerService.cs
+++ b/AskGenAi.Application/UseCases/ClassNormalizerService.cs
@@ -1,21 +1,20 @@
-﻿using AskGenAi.Common.Services;
-using AskGenAi.Core.Entities;
+﻿using AskGenAi.Core.Entities;
 using AskGenAi.Core.Interfaces;
 
 namespace AskGenAi.Application.UseCases;
 
 // </inheritdoc>
-public class ClassNormalizerService(IRepository<Question> questionRepository, IFilePath filePath) : IClassNormalizerService
+public class ClassNormalizerService(
+    IRepository<Question> questionRepository,
+    IFilePath filePath,
+    IJsonFileSerializer<Discipline> disciplineFileSerializer,
+    IJsonFileSerializer<Question> questionFileSerializer) : IClassNormalizerService
 {
-    // it is used like composition for the file repository
-    private readonly IJsonFileSerializer<Discipline> _disciplineFileSerializer = new JsonFileSerializer<Discipline>();
-    private readonly IJsonFileSerializer<Question> _questionFileSerializer = new JsonFileSerializer<Question>();
-
     // </inheritdoc>
     public async Task NormalizeDisciplineAsync()
     {
         var normalizeEntities =
-            await _disciplineFileSerializer.DeserializeAsync(filePath.GetLocalDisciplinePath());
+            await disciplineFileSerializer.DeserializeAsync(filePath.GetLocalDisciplinePath());
 
         if (normalizeEntities is null || normalizeEntities.Data.Count == 0)
         {
@@ -34,7 +33,7 @@ public class ClassNormalizerService(IRepository<Question> questionRepository, IF
 
         var newDisciplinePath = filePath.GetLocalNewDisciplinePath(newVersion);
         var serializedEntities =
-            await _disciplineFileSerializer.SerializeAsync(normalizeEntities, newDisciplinePath);
+            await disciplineFileSerializer.SerializeAsync(normalizeEntities, newDisciplinePath);
 
         Console.WriteLine("Saved content :\n" + serializedEntities + "\nFile Path: " + newDisciplinePath);
     }
@@ -42,7 +41,7 @@ public class ClassNormalizerService(IRepository<Question> questionRepository, IF
     // </inheritdoc>
     public async Task NormalizeQuestionAsync()
     {
-        var normalizeEntities = await _questionFileSerializer.DeserializeAsync(filePath.GetLocalQuestionsPath());
+        var normalizeEntities = await questionFileSerializer.DeserializeAsync(filePath.GetLocalQuestionsPath());
 
         if (normalizeEntities is null || normalizeEntities.Data.Count == 0)
         {
@@ -61,7 +60,7 @@ public class ClassNormalizerService(IRepository<Question> questionRepository, IF
 
         var newQuestionsPath = filePath.GetLocalNewQuestionsPath(newVersion);
         var serializedEntities =
-            await _questionFileSerializer.SerializeAsync(normalizeEntities, newQuestionsPath);
+            await questionFileSerializer.SerializeAsync(normalizeEntities, newQuestionsPath);
 
         Console.WriteLine("Saved content :\n" + serializedEntities + "\nFile Path: " + newQuestionsPath);
     }
@@ -91,7 +90,7 @@ public class ClassNormalizerService(IRepository<Question> questionRepository, IF
 
         var questionsFullPath = filePath.GetLocalQuestionsFullPath();
         var serializedEntities =
-            await _questionFileSerializer.SerializeAsync(normalizeEntitiesFull, questionsFullPath);
+            await questionFileSerializer.SerializeAsync(normalizeEntitiesFull, questionsFullPath);
 
         Console.WriteLine("Saved content :\n" + serializedEntities + "\nFile Path: " + questionsFullPath);
         Console.WriteLine("Total saved items " + normalizeEntitiesFull.Data.Count);
@@ -100,7 +99,7 @@ public class ClassNormalizerService(IRepository<Question> questionRepository, IF
     private async Task<IEnumerable<Question>> NormalizeQuestionAsync(string questionsFilename)
     {
         var normalizeEntities =
-            await _questionFileSerializer.DeserializeAsync(filePath.GetLocalQuestionsPath(questionsFilename));
+            await questionFileSerializer.DeserializeAsync(filePath.GetLocalQuestionsPath(questionsFilename));
 
         if (normalizeEntities is null || normalizeEntities.Data.Count == 0)
         {

--- a/AskGenAi.Common/AskGenAi.Common.csproj
+++ b/AskGenAi.Common/AskGenAi.Common.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AskGenAi.Core\AskGenAi.Core.csproj" />
   </ItemGroup>
 

--- a/AskGenAi.Common/ServiceCollectionExtensions.cs
+++ b/AskGenAi.Common/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿using AskGenAi.Common.Services;
+using AskGenAi.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AskGenAi.Common;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddCommonServices(this IServiceCollection services)
+    {
+        services.AddTransient(typeof(IJsonFileSerializer<>), typeof(JsonFileSerializer<>));
+
+        return services;
+    }
+}

--- a/AskGenAi.Core/Interfaces/IFilePath.cs
+++ b/AskGenAi.Core/Interfaces/IFilePath.cs
@@ -60,4 +60,11 @@ public interface IFilePath
     /// </summary>
     /// <returns></returns>
     string[] GetQuestionsListFilename();
+
+    /// <summary>
+    /// Gets the local full path by type
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    string GetLocalFullPathByType(Type type);
 }

--- a/AskGenAi.Infrastructure/AskGenAi.Infrastructure.csproj
+++ b/AskGenAi.Infrastructure/AskGenAi.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.25.0" />

--- a/AskGenAi.Infrastructure/FileSystem/FilePath.cs
+++ b/AskGenAi.Infrastructure/FileSystem/FilePath.cs
@@ -1,4 +1,5 @@
-﻿using AskGenAi.Core.Interfaces;
+﻿using AskGenAi.Core.Entities;
+using AskGenAi.Core.Interfaces;
 
 namespace AskGenAi.Infrastructure.FileSystem;
 
@@ -26,6 +27,18 @@ public class FilePath : IFilePath
             "questions21", "questions22", "questions23",
             "questions31", "questions32"
         ];
+    }
+
+    // </inheritdoc>
+    public string GetLocalFullPathByType(Type type)
+    {
+        return type switch
+        {
+            not null when type == typeof(Question) => GetLocalQuestionsFullPath(),
+            not null when type == typeof(Discipline) => GetLocalDisciplinesFullPath(),
+            not null when type == typeof(Response) => GetLocalResponsesFullPath(),
+            _ => string.Empty
+        };
     }
 
     // </inheritdoc>

--- a/AskGenAi.Infrastructure/Persistence/FileRepository.cs
+++ b/AskGenAi.Infrastructure/Persistence/FileRepository.cs
@@ -1,5 +1,4 @@
-﻿using AskGenAi.Common.Services;
-using AskGenAi.Core.Entities;
+﻿using AskGenAi.Core.Entities;
 using AskGenAi.Core.Interfaces;
 
 namespace AskGenAi.Infrastructure.Persistence;
@@ -9,15 +8,16 @@ namespace AskGenAi.Infrastructure.Persistence;
 public class FileRepository<T> : IRepository<T> where T : IEntity
 {
     // it is used like composition for the file repository
-    private readonly IJsonFileSerializer<T> _jsonFileSerializer = new JsonFileSerializer<T>();
+    private readonly IJsonFileSerializer<T> _jsonFileSerializer;
 
     private readonly string _filePath;
     private readonly List<T> _entities;
     private readonly string _version;
     
-    public FileRepository(string filePath)
+    public FileRepository(IJsonFileSerializer<T> jsonFileSerializer, IFilePath filePathService)
     {
-        _filePath = filePath;
+        _jsonFileSerializer = jsonFileSerializer;
+        _filePath = filePathService.GetLocalFullPathByType(typeof(T));
         _entities = new List<T>();
         _version = string.Empty;
 

--- a/AskGenAi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/AskGenAi.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using AskGenAi.Infrastructure.AIServices;
+using AskGenAi.Infrastructure.FileSystem;
+using AskGenAi.Infrastructure.Persistence;
+using AskGenAi.Core.Interfaces;
+
+namespace AskGenAi.Infrastructure;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfrastructureServices(this IServiceCollection services)
+    {
+        services.AddScoped<IChatModelManager, AzureOpenAiChatCompletion>();
+
+        services.AddSingleton<IFilePath, FilePath>();
+
+        services.AddScoped(typeof(IRepository<>), typeof(FileRepository<>));
+        //services.AddScoped(typeof(IRepository<>), typeof(InMemoryRepository<>));
+
+        return services;
+    }
+}

--- a/AskGenAi.Presentation/Program.cs
+++ b/AskGenAi.Presentation/Program.cs
@@ -1,22 +1,18 @@
-﻿using AskGenAi.Application.Services;
-using AskGenAi.Application.UseCases;
-using AskGenAi.Core.Entities;
+﻿using Microsoft.Extensions.DependencyInjection;
+
+using AskGenAi.Application;
+using AskGenAi.Common;
 using AskGenAi.Core.Interfaces;
-using AskGenAi.Infrastructure.AIServices;
-using AskGenAi.Infrastructure.FileSystem;
-using AskGenAi.Infrastructure.Persistence;
+using AskGenAi.Infrastructure;
 
-IFilePath filePath = new FilePath();
-IClassNormalizerService classNormalizerService =
-    new ClassNormalizerService(new FileRepository<Question>(filePath.GetLocalQuestionsFullPath()), filePath);
-//await classNormalizerService.NormalizeQuestionsAsync();
+var serviceProvider = new ServiceCollection()
+    .AddApplicationServices()
+    .AddCommonServices()
+    .AddInfrastructureServices()
+    .BuildServiceProvider();
 
-IResponseAiGenerator responseAiGenerator = new ResponseAiGenerator(
-    new AzureOpenAiChatCompletion(),
-    new HistoryBuilder(),
-    new FileRepository<Discipline>(filePath.GetLocalDisciplinesFullPath()),
-    new FileRepository<Question>(filePath.GetLocalQuestionsFullPath()),
-    new FileRepository<Response>(filePath.GetLocalResponsesFullPath())
-);
+var classNormalizerService = serviceProvider.GetRequiredService<IClassNormalizerService>();
+//await classNormalizerService.NormalizeQuestionAsync();
 
+var responseAiGenerator = serviceProvider.GetRequiredService<IResponseAiGenerator>();
 await responseAiGenerator.RunAsync();


### PR DESCRIPTION
Refactor to use dependency injection across projects

Updated project files to remove unnecessary package references and add Microsoft.Extensions.DependencyInjection. Refactored ClassNormalizerService and FileRepository to use dependency injection. Added new method to IFilePath interface and implemented it in FilePath. Refactored Program.cs to set up and use ServiceCollection. Added ServiceCollectionExtensions for service registration.