### PR TITLE
#2 Refactor and add tests for various classes

### DIFF
--- a/AskGenAi.Application/Services/PersonalityHelper.cs
+++ b/AskGenAi.Application/Services/PersonalityHelper.cs
@@ -5,7 +5,7 @@ namespace AskGenAi.Application.Services;
 /// <summary>
 /// Represents a helper class that provides personality-related functionality , but make a table for the switch statement
 /// </summary>
-public class PersonalityHelper
+public static class PersonalityHelper
 {
     private const string DetNetDeveloper = ".Net C# developer";
     private const string Default = "Developer";

--- a/AskGenAi.Application/UseCases/ClassNormalizerService.cs
+++ b/AskGenAi.Application/UseCases/ClassNormalizerService.cs
@@ -79,7 +79,7 @@ public class ClassNormalizerService(
             var normalizeEntities = await NormalizeQuestionAsync(questionsFilename);
 
             var enumerable = normalizeEntities as Question[] ?? normalizeEntities.ToArray();
-            if (!enumerable.Any())
+            if (enumerable.Length == 0) 
             {
                 Console.WriteLine("No" + nameof(Question) + "classes found");
                 continue;

--- a/AskGenAi.Application/UseCases/ResponseAiGenerator.cs
+++ b/AskGenAi.Application/UseCases/ResponseAiGenerator.cs
@@ -10,9 +10,12 @@ public class ResponseAiGenerator(
     IHistoryBuilder historyBuilder,
     IRepository<Discipline> disciplineRepository,
     IRepository<Question> questionRepository,
-    IRepository<Response> responseRepository)
+    IRepository<Response> responseRepository,
+    TimeSpan? delayDuration = null)
     : IResponseAiGenerator
 {
+    private readonly TimeSpan _delayDuration = delayDuration ?? TimeSpan.FromSeconds(30);
+    
     // </inheritdoc>
     public async Task RunAsync()
     {
@@ -41,7 +44,7 @@ public class ResponseAiGenerator(
             foreach (var question in questionsForDiscipline)
             {
                 // If the response to the question already exists, skip it
-                if (responses.Any(r => r.QuestionId == question.Id))
+                if (Array.Exists(responses, r => r.QuestionId == question.Id))
                 {
                     continue;
                 }
@@ -60,7 +63,7 @@ public class ResponseAiGenerator(
                 });
 
                 // make calls to the chat completion service to get the response with some delay 40 sec between each question
-                await Task.Delay(TimeSpan.FromSeconds(30));
+                await Task.Delay(_delayDuration);
             }
         }
     }

--- a/AskGenAi.Infrastructure/FileSystem/FilePath.cs
+++ b/AskGenAi.Infrastructure/FileSystem/FilePath.cs
@@ -71,15 +71,15 @@ public class FilePath : IFilePath
     }
 
     // </inheritdoc>
-    public string GetLocalQuestionsPath()
-    {
-        return Path.Combine(LocalPath, FilesPath, QuestionsFilename + Extension);
-    }
-
-    // </inheritdoc>
     public string GetLocalNewQuestionsPath(string newVersion)
     {
         return Path.Combine(LocalPath, FilesPath, QuestionsFilename + "V" + newVersion + Extension);
+    }
+
+    // </inheritdoc>
+    public string GetLocalQuestionsPath()
+    {
+        return Path.Combine(LocalPath, FilesPath, QuestionsFilename + Extension);
     }
 
     // </inheritdoc>

--- a/AskGenAi.Infrastructure/Persistence/FileRepository.cs
+++ b/AskGenAi.Infrastructure/Persistence/FileRepository.cs
@@ -11,14 +11,13 @@ public class FileRepository<T> : IRepository<T> where T : IEntity
     private readonly IJsonFileSerializer<T> _jsonFileSerializer;
 
     private readonly string _filePath;
-    private readonly List<T> _entities;
+    private readonly List<T> _entities = [];
     private readonly string _version;
     
     public FileRepository(IJsonFileSerializer<T> jsonFileSerializer, IFilePath filePathService)
     {
         _jsonFileSerializer = jsonFileSerializer;
         _filePath = filePathService.GetLocalFullPathByType(typeof(T));
-        _entities = new List<T>();
         _version = string.Empty;
 
         if (!File.Exists(_filePath))

--- a/AskGenAi.xTests/Application/Services/HistoryBuilderTests.cs
+++ b/AskGenAi.xTests/Application/Services/HistoryBuilderTests.cs
@@ -1,0 +1,57 @@
+using AskGenAi.Application.Services;
+using AskGenAi.Core.Entities;
+using FluentAssertions;
+
+namespace AskGenAi.xTests.Application.Services;
+
+public class HistoryBuilderTests
+{
+    private readonly HistoryBuilder _historyBuilder = new();
+
+    [Fact]
+    public void BuildQuestionHistory_ShouldReturnEmptyString_WhenRequiredParametersAreNullOrWhitespace()
+    {
+        // Act
+        var result = _historyBuilder.BuildQuestionHistory(null, "tech", "discipline", "subDiscipline");
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildQuestionHistory_ShouldReturnFormattedString_WhenAllParametersAreProvided()
+    {
+        // Arrange
+        var personality = PersonalityHelper.GetPersonality(DisciplineType.NetRuntime);
+        const string technologies = "C#, .NET";
+        const string discipline = "Software Engineering";
+        const string subDiscipline = "Backend Development";
+
+        // Act
+        var result = _historyBuilder.BuildQuestionHistory(personality, technologies, discipline, subDiscipline);
+
+        // Assert
+        result.Should().Contain(personality);
+        result.Should().Contain(technologies);
+        result.Should().Contain(discipline);
+        result.Should().Contain(subDiscipline);
+    }
+
+    [Fact]
+    public void BuildQuestionHistory_ShouldReturnFormattedString_WhenSubDisciplineIsNull()
+    {
+        // Arrange
+        var personality = PersonalityHelper.GetPersonality(DisciplineType.DatabasesEventProcessing);
+        const string technologies = "C#, .NET";
+        const string discipline = "Software Engineering";
+
+        // Act
+        var result = _historyBuilder.BuildQuestionHistory(personality, technologies, discipline, null);
+
+        // Assert
+        result.Should().Contain(personality);
+        result.Should().Contain(technologies);
+        result.Should().Contain(discipline);
+        result.Should().NotContain("null");
+    }
+}

--- a/AskGenAi.xTests/Application/UseCases/ClassNormalizerServiceTests.cs
+++ b/AskGenAi.xTests/Application/UseCases/ClassNormalizerServiceTests.cs
@@ -1,0 +1,84 @@
+using AskGenAi.Application.UseCases;
+using AskGenAi.Core.Entities;
+using AskGenAi.Core.Interfaces;
+using Moq;
+
+namespace AskGenAi.xTests.Application.UseCases;
+
+public class ClassNormalizerServiceTests
+{
+    private readonly Mock<IFilePath> _mockFilePath;
+    private readonly Mock<IJsonFileSerializer<Discipline>> _mockDisciplineFileSerializer;
+    private readonly Mock<IJsonFileSerializer<Question>> _mockQuestionFileSerializer;
+    private readonly ClassNormalizerService _classNormalizerService;
+
+    public ClassNormalizerServiceTests()
+    {
+        Mock<IRepository<Question>> mockQuestionRepository = new();
+        _mockFilePath = new Mock<IFilePath>();
+        _mockDisciplineFileSerializer = new Mock<IJsonFileSerializer<Discipline>>();
+        _mockQuestionFileSerializer = new Mock<IJsonFileSerializer<Question>>();
+
+        _classNormalizerService = new ClassNormalizerService(
+            mockQuestionRepository.Object,
+            _mockFilePath.Object,
+            _mockDisciplineFileSerializer.Object,
+            _mockQuestionFileSerializer.Object);
+    }
+
+    [Fact]
+    public async Task NormalizeDisciplineAsync_ShouldNormalizeAndSaveDisciplines()
+    {
+        // Arrange
+        var disciplines = new List<Discipline> { new() { Id = Guid.Empty } };
+        var root = new Root<Discipline> { Data = disciplines, Version = "1.0.0" };
+        _mockFilePath.Setup(x => x.GetLocalDisciplinePath()).Returns("disciplinePath");
+        _mockDisciplineFileSerializer.Setup(x => x.DeserializeAsync("disciplinePath")).ReturnsAsync(root);
+
+        // Act
+        await _classNormalizerService.NormalizeDisciplineAsync();
+
+        // Assert
+        _mockDisciplineFileSerializer.Verify(
+            x => x.SerializeAsync(It.Is<Root<Discipline>>(r => r.Data.TrueForAll(d => d.Id != Guid.Empty)),
+                It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task NormalizeQuestionAsync_ShouldNormalizeAndSaveQuestions()
+    {
+        // Arrange
+        var questions = new List<Question> { new() { Id = Guid.Empty } };
+        var root = new Root<Question> { Data = questions, Version = "1.0.0" };
+        _mockFilePath.Setup(x => x.GetLocalQuestionsPath()).Returns("questionsPath");
+        _mockQuestionFileSerializer.Setup(x => x.DeserializeAsync("questionsPath")).ReturnsAsync(root);
+
+        // Act
+        await _classNormalizerService.NormalizeQuestionAsync();
+
+        // Assert
+        _mockQuestionFileSerializer.Verify(
+            x => x.SerializeAsync(It.Is<Root<Question>>(r => r.Data.TrueForAll(q => q.Id != Guid.Empty)),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NormalizeQuestionsAsync_ShouldNormalizeAndSaveAllQuestions()
+    {
+        // Arrange
+        var questions = new List<Question> { new() { Id = Guid.Empty } };
+        var root = new Root<Question> { Data = questions, Version = "1.0.0" };
+        _mockFilePath.Setup(x => x.GetQuestionsListFilename()).Returns(["questionsFile1", "questionsFile2"]);
+        _mockQuestionFileSerializer.Setup(x => x.DeserializeAsync(It.IsAny<string>())).ReturnsAsync(root);
+
+        // Act
+        await _classNormalizerService.NormalizeQuestionsAsync();
+
+        // Assert
+        _mockQuestionFileSerializer.Verify(
+            x => x.SerializeAsync(It.Is<Root<Question>>(r => r.Data.TrueForAll(q => q.Id != Guid.Empty)),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+}

--- a/AskGenAi.xTests/Application/UseCases/ResponseAiGeneratorTests.cs
+++ b/AskGenAi.xTests/Application/UseCases/ResponseAiGeneratorTests.cs
@@ -1,0 +1,103 @@
+using AskGenAi.Application.UseCases;
+using AskGenAi.Core.Entities;
+using AskGenAi.Core.Interfaces;
+using Moq;
+using AutoFixture;
+
+namespace AskGenAi.xTests.Application.UseCases;
+
+public class ResponseAiGeneratorTests
+{
+    private readonly Fixture _fixture = new();
+    private readonly Mock<IChatModelManager> _mockChatModelManager;
+    private readonly Mock<IHistoryBuilder> _mockHistoryBuilder;
+    private readonly Mock<IRepository<Discipline>> _mockDisciplineRepository;
+    private readonly Mock<IRepository<Question>> _mockQuestionRepository;
+    private readonly Mock<IRepository<Response>> _mockResponseRepository;
+    private readonly ResponseAiGenerator _responseAiGenerator;
+
+    public ResponseAiGeneratorTests()
+    {
+        _mockChatModelManager = new Mock<IChatModelManager>();
+        _mockHistoryBuilder = new Mock<IHistoryBuilder>();
+        _mockDisciplineRepository = new Mock<IRepository<Discipline>>();
+        _mockQuestionRepository = new Mock<IRepository<Question>>();
+        _mockResponseRepository = new Mock<IRepository<Response>>();
+
+        _responseAiGenerator = new ResponseAiGenerator(
+            _mockChatModelManager.Object,
+            _mockHistoryBuilder.Object,
+            _mockDisciplineRepository.Object,
+            _mockQuestionRepository.Object,
+            _mockResponseRepository.Object,
+            TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldGenerateResponsesForQuestions()
+    {
+        // Arrange
+        var disciplines = new List<Discipline>
+        {
+            new()
+            {
+                Id = _fixture.Create<Guid>(), Type = 1, Title = "Discipline1", Scope = "Scope1", Subtitle = "Subtitle1"
+            }
+        };
+        var questions = new List<Question>
+        {
+            new() { Id = _fixture.Create<Guid>(), DisciplineType = 1, Context = "Question1" }
+        };
+        var responses = Array.Empty<Response>();
+
+        _mockDisciplineRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(disciplines);
+        _mockQuestionRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(questions);
+        _mockResponseRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(responses);
+        _mockHistoryBuilder
+            .Setup(x => x.BuildQuestionHistory(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>())).Returns("HistoryMessage");
+        _mockChatModelManager.Setup(x => x.GetChatMessageContentAsync()).ReturnsAsync("Response1");
+
+        // Act
+        await _responseAiGenerator.RunAsync();
+
+        // Assert
+        _mockChatModelManager.Verify(x => x.AddSystemMessage("HistoryMessage"), Times.Once);
+        _mockChatModelManager.Verify(x => x.AddUserMessage("Question1"), Times.Once);
+        _mockResponseRepository.Verify(
+            x => x.AddAsync(It.Is<Response>(r => r.Context == "Response1" && r.QuestionId == questions[0].Id)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldSkipExistingResponses()
+    {
+        // Arrange
+        var disciplines = new List<Discipline>
+        {
+            new()
+            {
+                Id = _fixture.Create<Guid>(), Type = 1, Title = "Discipline1", Scope = "Scope1", Subtitle = "Subtitle1"
+            }
+        };
+        var questions = new List<Question>
+        {
+            new() { Id = _fixture.Create<Guid>(), DisciplineType = 1, Context = "Question1" }
+        };
+        var responses = new List<Response>
+        {
+            new() { Id = _fixture.Create<Guid>(), QuestionId = questions[0].Id, Context = "ExistingResponse" }
+        };
+
+        _mockDisciplineRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(disciplines);
+        _mockQuestionRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(questions);
+        _mockResponseRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(responses);
+
+        // Act
+        await _responseAiGenerator.RunAsync();
+
+        // Assert
+        _mockChatModelManager.Verify(x => x.AddUserMessage(It.IsAny<string>()), Times.Never);
+        _mockResponseRepository.Verify(x => x.AddAsync(It.IsAny<Response>()), Times.Never);
+    }
+}

--- a/AskGenAi.xTests/AskGenAi.xTests.csproj
+++ b/AskGenAi.xTests/AskGenAi.xTests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AskGenAi.Application\AskGenAi.Application.csproj" />
+    <ProjectReference Include="..\AskGenAi.Infrastructure\AskGenAi.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/AskGenAi.xTests/Common/Services/JsonFileSerializerTests.cs
+++ b/AskGenAi.xTests/Common/Services/JsonFileSerializerTests.cs
@@ -1,0 +1,103 @@
+using AskGenAi.Common.Services;
+using AskGenAi.Core.Entities;
+using FluentAssertions;
+using AskGenAi.Core.Interfaces;
+using AutoFixture;
+using System.Text.Json.Serialization;
+
+namespace AskGenAi.xTests.Common.Services;
+
+public class JsonFileSerializerTests
+{
+    private readonly IJsonFileSerializer<TestEntity> _serializer = new JsonFileSerializer<TestEntity>();
+    private const string FilePath = "test.json";
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public async Task DeserializeAsync_ShouldReturnRootObject_WhenFileIsValid()
+    {
+        // Arrange
+        var guid = _fixture.Create<Guid>();
+        var json = "{\"version\":\"1.0\",\"data\":[{\"id\":\"" + guid + "\",\"name\":\"Test\"}]}";
+        await File.WriteAllTextAsync(FilePath, json);
+
+        // Act
+        var result = await _serializer.DeserializeAsync(FilePath);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("1.0");
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Id.Should().Be(guid);
+        result.Data[0].Name.Should().Be("Test");
+    }
+
+    [Fact]
+    public async Task SerializeAsync_ShouldWriteToFile_WhenObjectIsValid()
+    {
+        // Arrange
+        var guid = _fixture.Create<Guid>();
+        var root = new Root<TestEntity>
+        {
+            Version = "1.0",
+            Data = [new TestEntity() { Id = guid, Name = "Test" }]
+        };
+
+        // Act
+        var result = await _serializer.SerializeAsync(root, FilePath);
+
+        // Assert
+        var fileContent = await File.ReadAllTextAsync(FilePath);
+        fileContent.Should().Be(result);
+        fileContent.Should().Contain("\"version\": \"1.0\"");
+        fileContent.Should().Contain("\"id\": \"" + guid + "\"");
+        fileContent.Should().Contain("\"name\": \"Test\"");
+    }
+
+    [Fact]
+    public void Deserialize_ShouldReturnRootObject_WhenFileIsValid()
+    {
+        var guid = _fixture.Create<Guid>();
+        var json = "{\"version\":\"1.0\",\"data\":[{\"id\":\"" + guid + "\",\"name\":\"Test\"}]}";
+        File.WriteAllText(FilePath, json);
+
+        // Act
+        var result = _serializer.Deserialize(FilePath);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("1.0");
+        result.Data.Should().HaveCount(1);
+        result.Data[0].Id.Should().Be(guid);
+        result.Data[0].Name.Should().Be("Test");
+    }
+
+    [Fact]
+    public void Serialize_ShouldWriteToFile_WhenObjectIsValid()
+    {
+        // Arrange
+        var guid = _fixture.Create<Guid>();
+        var root = new Root<TestEntity>
+        {
+            Version = "1.0",
+            Data = [new TestEntity() { Id = guid, Name = "Test" }]
+        };
+
+        // Act
+        var result = _serializer.Serialize(root, FilePath);
+
+        // Assert
+        var fileContent = File.ReadAllText(FilePath);
+        fileContent.Should().Be(result);
+        fileContent.Should().Contain("\"version\": \"1.0\"");
+        fileContent.Should().Contain("\"id\": \"" + guid + "\"");
+        fileContent.Should().Contain("\"name\": \"Test\"");
+    }
+}
+
+public class TestEntity : IEntity
+{
+    [JsonPropertyName("id")] public Guid Id { get; set; }
+
+    [JsonPropertyName("name")] public string Name { get; set; } = default!;
+}

--- a/AskGenAi.xTests/Infrastructure/FileSystem/FilePathTests.cs
+++ b/AskGenAi.xTests/Infrastructure/FileSystem/FilePathTests.cs
@@ -1,0 +1,76 @@
+using AskGenAi.Core.Entities;
+using AskGenAi.Infrastructure.FileSystem;
+using FluentAssertions;
+
+namespace AskGenAi.xTests.Infrastructure.FileSystem;
+
+public class FilePathTests
+{
+    private readonly FilePath _filePath = new();
+
+    [Fact]
+    public void GetQuestionsListFilename_ShouldReturnCorrectFilenames()
+    {
+        // Act
+        var result = _filePath.GetQuestionsListFilename();
+
+        // Assert
+        result.Should().Contain(
+        [
+            "questions1", "questions2", "questions3", "questions4",
+            "questions11", "questions12", "questions13", "questions14",
+            "questions21", "questions22", "questions23",
+            "questions31", "questions32"
+        ]);
+    }
+
+    [Fact]
+    public void GetLocalQuestionsFullPath_ShouldReturnCorrectPath()
+    {
+        // Act
+        var result = _filePath.GetLocalQuestionsFullPath();
+
+        // Assert
+        result.Should().EndWith("AskGenAi.Infrastructure/Resources/question.json");
+    }
+
+    [Fact]
+    public void GetLocalFullPathByType_ShouldReturnCorrectPath_ForQuestionType()
+    {
+        // Act
+        var result = _filePath.GetLocalFullPathByType(typeof(Question));
+
+        // Assert
+        result.Should().EndWith("AskGenAi.Infrastructure/Resources/question.json");
+    }
+
+    [Fact]
+    public void GetLocalFullPathByType_ShouldReturnCorrectPath_ForDisciplineType()
+    {
+        // Act
+        var result = _filePath.GetLocalFullPathByType(typeof(Discipline));
+
+        // Assert
+        result.Should().EndWith("AskGenAi.Infrastructure/Resources/disciplineV1.json");
+    }
+
+    [Fact]
+    public void GetLocalFullPathByType_ShouldReturnCorrectPath_ForResponseType()
+    {
+        // Act
+        var result = _filePath.GetLocalFullPathByType(typeof(Response));
+
+        // Assert
+        result.Should().EndWith("AskGenAi.Infrastructure/Resources/response.json");
+    }
+
+    [Fact]
+    public void GetLocalFullPathByType_ShouldReturnEmptyString_ForUnknownType()
+    {
+        // Act
+        var result = _filePath.GetLocalFullPathByType(typeof(string));
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+}

--- a/AskGenAi.xTests/Infrastructure/Persistence/FileRepositoryTests.cs
+++ b/AskGenAi.xTests/Infrastructure/Persistence/FileRepositoryTests.cs
@@ -1,0 +1,99 @@
+using AskGenAi.Core.Entities;
+using AskGenAi.Core.Interfaces;
+using AskGenAi.Infrastructure.Persistence;
+using AutoFixture;
+using Moq;
+
+namespace AskGenAi.xTests.Infrastructure.Persistence;
+
+public class FileRepositoryTests
+{
+    private const string TestFilePath = "test.json";
+
+    private readonly Mock<IJsonFileSerializer<Common.Services.TestEntity>> _mockJsonFileSerializer;
+    private readonly FileRepository<Common.Services.TestEntity> _fileRepository;
+    private readonly Fixture _fixture = new();
+    private readonly List<Common.Services.TestEntity> _entities;
+    private readonly Common.Services.TestEntity _entity;
+    private readonly Guid _entityId;
+
+    public FileRepositoryTests()
+    {
+        _mockJsonFileSerializer = new Mock<IJsonFileSerializer<Common.Services.TestEntity>>();
+        Mock<IFilePath> mockFilePathService = new();
+        mockFilePathService.Setup(x => x.GetLocalFullPathByType(It.IsAny<Type>())).Returns(TestFilePath);
+
+        _entityId = _fixture.Create<Guid>();
+        _entity = new Common.Services.TestEntity { Id = _entityId };
+        _entities = new List<Common.Services.TestEntity> { _entity };
+        _mockJsonFileSerializer.Setup(x => x.Deserialize(TestFilePath))
+            .Returns(new Root<Common.Services.TestEntity> { Data = _entities });
+
+        _fileRepository =
+            new FileRepository<Common.Services.TestEntity>(_mockJsonFileSerializer.Object, mockFilePathService.Object);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnAllEntities()
+    {
+        // Act
+        var result = await _fileRepository.GetAllAsync();
+
+        // Assert
+        Assert.Equal(_entities, result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnEntity_WhenEntityExists()
+    {
+        // Act
+        var result = await _fileRepository.GetByIdAsync(_entityId);
+
+        // Assert
+        Assert.Equal(_entityId, result?.Id);
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldAddEntity()
+    {
+        // Arrange
+        var testEntity = new Common.Services.TestEntity { Id = Guid.NewGuid() };
+
+        // Act
+        await _fileRepository.AddAsync(testEntity);
+
+        // Assert
+        _mockJsonFileSerializer.Verify(
+            x => x.SerializeAsync(It.Is<Root<Common.Services.TestEntity>>(r => r.Data.Contains(testEntity)),
+                TestFilePath), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateEntity_WhenEntityExists()
+    {
+        // Arrange
+        var updatedEntity = new Common.Services.TestEntity { Id = _entityId, Name = "Updated" };
+
+        // Act
+        await _fileRepository.UpdateAsync(updatedEntity);
+
+        // Assert
+        _mockJsonFileSerializer.Verify(
+            x => x.SerializeAsync(
+                It.Is<Root<Common.Services.TestEntity>>(
+                    r => r.Data.Contains(updatedEntity) && !r.Data.Contains(_entity)),
+                TestFilePath), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveEntity_WhenEntityExists()
+    {
+        // Act
+        await _fileRepository.DeleteAsync(_entityId);
+
+        // Assert
+        _mockJsonFileSerializer.Verify(
+            x => x.SerializeAsync(It.Is<Root<Common.Services.TestEntity>>(r => !r.Data.Contains(_entity)),
+                TestFilePath), Times.Once);
+    }
+}

--- a/AskGenAi.xTests/Infrastructure/Persistence/InMemoryRepositoryTests.cs
+++ b/AskGenAi.xTests/Infrastructure/Persistence/InMemoryRepositoryTests.cs
@@ -1,0 +1,125 @@
+using AskGenAi.Core.Entities;
+using AskGenAi.Infrastructure.Persistence;
+using FluentAssertions;
+
+namespace AskGenAi.xTests.Infrastructure.Persistence;
+
+public class InMemoryRepositoryTests
+{
+    private readonly InMemoryRepository<TestEntity> _repository = new();
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnAllEntities()
+    {
+        // Arrange
+        var entity1 = new TestEntity { Id = Guid.NewGuid(), Name = "Entity1" };
+        var entity2 = new TestEntity { Id = Guid.NewGuid(), Name = "Entity2" };
+        await _repository.AddAsync(entity1);
+        await _repository.AddAsync(entity2);
+
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().Contain([entity1, entity2]);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnEntity_WhenEntityExists()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = Guid.NewGuid(), Name = "Entity" };
+        await _repository.AddAsync(entity);
+
+        // Act
+        var result = await _repository.GetByIdAsync(entity.Id);
+
+        // Assert
+        result.Should().Be(entity);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenEntityDoesNotExist()
+    {
+        // Act
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldAddEntity()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = Guid.NewGuid(), Name = "Entity" };
+
+        // Act
+        await _repository.AddAsync(entity);
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().Contain(entity);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateEntity_WhenEntityExists()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = Guid.NewGuid(), Name = "Entity" };
+        await _repository.AddAsync(entity);
+        var updatedEntity = new TestEntity { Id = entity.Id, Name = "Updated Entity" };
+
+        // Act
+        await _repository.UpdateAsync(updatedEntity);
+        var result = await _repository.GetByIdAsync(entity.Id);
+
+        // Assert
+        result.Should().Be(updatedEntity);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldNotUpdateEntity_WhenEntityDoesNotExist()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = Guid.NewGuid(), Name = "Entity" };
+
+        // Act
+        await _repository.UpdateAsync(entity);
+        var result = await _repository.GetByIdAsync(entity.Id);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveEntity_WhenEntityExists()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = Guid.NewGuid(), Name = "Entity" };
+        await _repository.AddAsync(entity);
+
+        // Act
+        await _repository.DeleteAsync(entity.Id);
+        var result = await _repository.GetByIdAsync(entity.Id);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldNotThrow_WhenEntityDoesNotExist()
+    {
+        // Act
+        var act = async () => await _repository.DeleteAsync(Guid.NewGuid());
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+}
+
+public class TestEntity : IEntity
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+}

--- a/AskGenAi.xTests/SampleTests.cs
+++ b/AskGenAi.xTests/SampleTests.cs
@@ -1,0 +1,22 @@
+using AutoFixture;
+using FluentAssertions;
+
+namespace AskGenAi.xTests;
+
+public class SampleTests
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void ExampleTest_ShouldPass_WhenConditionIsMet()
+    {
+        // Arrange
+        var expectedValue = _fixture.Create<int>();
+
+        // Act
+        var actualValue = expectedValue;
+
+        // Assert
+        actualValue.Should().Be(expectedValue);
+    }
+}

--- a/GenAiApps.sln
+++ b/GenAiApps.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AskGenAi.Common", "AskGenAi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AskGenAi.Presentation", "AskGenAi.Presentation\AskGenAi.Presentation.csproj", "{BF2ABE19-1241-4C9E-8616-BEC851374ACC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AskGenAi.xTests", "AskGenAi.xTests\AskGenAi.xTests.csproj", "{E5F79DA7-3F38-41DA-81DC-6B46D05472CD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{BF2ABE19-1241-4C9E-8616-BEC851374ACC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF2ABE19-1241-4C9E-8616-BEC851374ACC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF2ABE19-1241-4C9E-8616-BEC851374ACC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5F79DA7-3F38-41DA-81DC-6B46D05472CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5F79DA7-3F38-41DA-81DC-6B46D05472CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5F79DA7-3F38-41DA-81DC-6B46D05472CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5F79DA7-3F38-41DA-81DC-6B46D05472CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Refactored several classes and added comprehensive unit tests:
- Made `PersonalityHelper` class static and added constants.
- Updated `ClassNormalizerService` to use `enumerable.Length == 0`.
- Enhanced `ResponseAiGenerator` with a new optional parameter and updated checks.
- Renamed methods and updated paths in `FilePath`.
- Initialized `_entities` list directly in `FileRepository`.
- Added `AskGenAi.xTests` project to the solution.
- Created new test projects and added sample tests using `AutoFixture` and `FluentAssertions`.
- Added tests for `HistoryBuilder`, `ClassNormalizerService`, `ResponseAiGenerator`, `JsonFileSerializer`, `FilePath`, and `FileRepository`.
- Introduced `InMemoryRepositoryTests` with various test methods to verify `InMemoryRepository` behavior.