### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/AskGenAi.Application/AskGenAi.Application.csproj
+++ b/AskGenAi.Application/AskGenAi.Application.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AskGenAi.Common/AskGenAi.Common.csproj
+++ b/AskGenAi.Common/AskGenAi.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AskGenAi.Infrastructure/AskGenAi.Infrastructure.csproj
+++ b/AskGenAi.Infrastructure/AskGenAi.Infrastructure.csproj
@@ -8,18 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.27.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.29.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AskGenAi.WebApi/AskGenAi.WebApi.csproj
+++ b/AskGenAi.WebApi/AskGenAi.WebApi.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AskGenAi.xTests/AskGenAi.xTests.csproj
+++ b/AskGenAi.xTests/AskGenAi.xTests.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
Updated the following project files to upgrade package versions:
- `AskGenAi.Application.csproj`: `Microsoft.Extensions.DependencyInjection` from `8.0.1` to `9.0.0`
- `AskGenAi.Common.csproj`: `Microsoft.Extensions.DependencyInjection` from `8.0.1` to `9.0.0`
- `AskGenAi.Infrastructure.csproj`: Multiple packages including `Microsoft.EntityFrameworkCore` and `Microsoft.Extensions.*` to `9.0.0`, and `Microsoft.SemanticKernel` to `1.29.0`
- `AskGenAi.WebApi.csproj`: `Microsoft.IdentityModel.Tokens` to `8.2.1`, `Swashbuckle.AspNetCore` to `7.0.0`, and `System.IdentityModel.Tokens.Jwt` to `8.2.1`
- `AskGenAi.xTests.csproj`: `FluentAssertions` to `6.12.2`, `Microsoft.EntityFrameworkCore.InMemory` to `9.0.0`, and `Microsoft.NET.Test.Sdk` to `17.12.0`